### PR TITLE
Fix issue where the 'h' is clipped when the stopwatch passes an hour.

### DIFF
--- a/src/main.qml
+++ b/src/main.qml
@@ -78,6 +78,7 @@ Application {
 
         Label {
             id: elapsedLabel
+            clip: false
             textFormat: Text.RichText
             anchors.centerIn: parent
             text: toTimeString(elapsed.value)


### PR DESCRIPTION
This fixes an issue where the 'h' is clipped, it was reported by @docgalaxyblock. Thanks for reporing!

Issue:
![aos-stopwatch-issue](https://user-images.githubusercontent.com/7857908/204052709-0fdec253-75f4-443a-a7ee-09957b38d8d8.jpg)

Fix:
![aos-stopwatch-fix](https://user-images.githubusercontent.com/7857908/204052707-3d6098b3-f2b6-4265-8b2b-4ddd7b4e8850.jpg)

