### PR TITLE
Move main library file to CMAKE_INSTALL_LIBDIR and add a launch script

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -19,6 +19,13 @@ ecm_find_qmlmodule(Nemo.Configuration 1.0)
 
 add_subdirectory(src)
 
+configure_file(${CMAKE_CURRENT_SOURCE_DIR}/asteroid-stopwatch.in
+	${CMAKE_BINARY_DIR}/asteroid-stopwatch
+	@ONLY)
+
+install(PROGRAMS ${CMAKE_BINARY_DIR}/asteroid-stopwatch
+	DESTINATION ${CMAKE_INSTALL_BINDIR})
+
 build_translations(i18n)
 generate_desktop(${CMAKE_SOURCE_DIR} asteroid-stopwatch)
 

--- a/asteroid-stopwatch.desktop.template
+++ b/asteroid-stopwatch.desktop.template
@@ -1,7 +1,7 @@
 [Desktop Entry]
 Type=Application
 Categories=Applications;
-Exec=invoker --single-instance --type=qtcomponents-qt5 /usr/bin/asteroid-stopwatch
+Exec=asteroid-stopwatch
 Icon=ios-stopwatch-outline
 X-Asteroid-Center-Color=#9800A6
 X-Asteroid-Outer-Color=#0C0009

--- a/asteroid-stopwatch.in
+++ b/asteroid-stopwatch.in
@@ -1,0 +1,3 @@
+#!/bin/sh
+
+exec invoker --single-instance --type=qtcomponents-qt5 @CMAKE_INSTALL_FULL_LIBDIR@/asteroid-stopwatch.so

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1,8 +1,8 @@
 add_library(asteroid-stopwatch main.cpp resources.qrc)
-set_target_properties(asteroid-stopwatch PROPERTIES PREFIX "" SUFFIX "")
+set_target_properties(asteroid-stopwatch PROPERTIES PREFIX "")
 
 target_link_libraries(asteroid-stopwatch PUBLIC
 	AsteroidApp)
 
 install(TARGETS asteroid-stopwatch
-	DESTINATION ${CMAKE_INSTALL_BINDIR})
+	DESTINATION ${CMAKE_INSTALL_LIBDIR})


### PR DESCRIPTION
Previously the main program file was installed to /usr/bin, mistakingly giving the impression it could be executed as is. However it isn't a binary but a library that gets executed through invoker. To prevent confusion move it to /usr/lib and add a launch script to /usr/bin instead which launches it through invoker