### PR TITLE
bugfix and feature: enlarged reset hit area, clock drift fix, lap mode

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1,8 +1,8 @@
-add_library(asteroid-stopwatch main.cpp resources.qrc)
+add_library(asteroid-stopwatch main.cpp StopwatchController.cpp resources.qrc)
 set_target_properties(asteroid-stopwatch PROPERTIES PREFIX "")
 
 target_link_libraries(asteroid-stopwatch PUBLIC
-	AsteroidApp)
+    AsteroidApp)
 
 install(TARGETS asteroid-stopwatch
-	DESTINATION ${CMAKE_INSTALL_LIBDIR})
+    DESTINATION ${CMAKE_INSTALL_LIBDIR})

--- a/src/LapPage.qml
+++ b/src/LapPage.qml
@@ -1,0 +1,204 @@
+/*
+ * Copyright (C) 2026 Timo Könnecke <github.com/moWerk>
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import QtQuick 2.9
+import org.asteroid.controls 1.0
+import org.asteroid.utils 1.0
+
+Item {
+    id: lapPage
+
+    property real elapsedMs: 0
+    property var lapList: []
+    property string swState: "zero"
+
+    signal lapRecorded()
+
+    function zeroPad(n) {
+        return (n < 10 ? "0" : "") + n
+    }
+
+    function toLapString(ms) {
+        var mod = Math.abs(ms)
+        var minutes = Math.floor(mod / 60000)
+        var seconds = Math.floor((mod % 60000) / 1000)
+        var tenth = Math.floor((mod % 1000) / 100)
+        if (minutes > 0) {
+            return zeroPad(minutes) + ":" + zeroPad(seconds) + "." + tenth
+        }
+        return zeroPad(seconds) + "." + tenth + "s"
+    }
+
+    function toDeltaString(ms) {
+        var sign = ms >= 0 ? "+" : "-"
+        var mod = Math.abs(ms)
+        var minutes = Math.floor(mod / 60000)
+        var seconds = Math.floor((mod % 60000) / 1000)
+        var tenth = Math.floor((mod % 1000) / 100)
+        if (minutes > 0) {
+            return sign + zeroPad(minutes) + ":" + zeroPad(seconds) + "." + tenth
+        }
+        return sign + zeroPad(seconds) + "." + tenth
+    }
+
+    // Full-page list, flows under the delta overlay
+    ListView {
+        id: lapListView
+        anchors.fill: parent
+        topMargin: Dims.h(30)
+        clip: false
+        footer: Item {
+            width: lapListView.width
+            height: DeviceSpecs.hasRoundScreen ? Dims.l(20) : Dims.l(8)
+        }
+        model: (lapPage.lapList ? lapPage.lapList.length : 0) + 1
+
+        delegate: Item {
+            width: lapListView.width
+            height: Dims.l(20)
+
+            readonly property bool isCurrentRow: index === 0
+            readonly property int lapIndex: index - 1
+
+            // Lap number — small, dimmed
+            Label {
+                id: rowLapNum
+                anchors {
+                    left: parent.left
+                    leftMargin: Dims.l(15)
+                    verticalCenter: parent.verticalCenter
+                }
+                font.pixelSize: Dims.l(6)
+                color: "#CCCCF3"
+                opacity: 0.6
+                text: {
+                    var total = lapPage.lapList ? lapPage.lapList.length : 0
+                    return isCurrentRow ? "L" + (total + 1) : "L" + (total - lapIndex)
+                }
+            }
+
+            // Split time or live running elapsed for current row
+            Label {
+                anchors {
+                    left: rowLapNum.right
+                    leftMargin: Dims.l(3)
+                    verticalCenter: parent.verticalCenter
+                }
+                font.pixelSize: Dims.l(8)
+                text: {
+                    if (isCurrentRow) {
+                        var mod = lapPage.elapsedMs < 0 ? 0 : lapPage.elapsedMs
+                        var lapArr = lapPage.lapList
+                        var base = (lapArr && lapArr.length > 0) ? lapArr[0] : 0
+                        mod = mod - base
+                        var h = Math.floor(mod / 3600000)
+                        var m = Math.floor((mod % 3600000) / 60000)
+                        var s = Math.floor((mod % 60000) / 1000)
+                        if (h > 0) return zeroPad(h) + "h" + zeroPad(m) + "m" + zeroPad(s) + "s"
+                        if (m > 0) return zeroPad(m) + "m" + zeroPad(s) + "s"
+                        return zeroPad(s) + "s"
+                    }
+                    var lapArr = lapPage.lapList
+                    var prev = (lapIndex + 1 < lapArr.length) ? lapArr[lapIndex + 1] : 0
+                    return toLapString(lapArr[lapIndex] - prev)
+                }
+            }
+
+            // Delta vs previous split — hidden on current row and first recorded lap
+            Label {
+                anchors {
+                    right: parent.right
+                    rightMargin: Dims.w(15)
+                    verticalCenter: parent.verticalCenter
+                }
+                font.pixelSize: Dims.l(6)
+                visible: !isCurrentRow && lapIndex + 1 < (lapPage.lapList ? lapPage.lapList.length : 0)
+                text: {
+                    var lapArr = lapPage.lapList
+                    if (!lapArr || lapIndex + 1 >= lapArr.length) return ""
+                    var prev = lapArr[lapIndex + 1]
+                    var prev2 = (lapIndex + 2 < lapArr.length) ? lapArr[lapIndex + 2] : 0
+                    return toDeltaString((lapArr[lapIndex] - prev) - (prev - prev2))
+                }
+                color: {
+                    var lapArr = lapPage.lapList
+                    if (!lapArr || lapIndex + 1 >= lapArr.length) return "#CCCCF3"
+                    var prev = lapArr[lapIndex + 1]
+                    var prev2 = (lapIndex + 2 < lapArr.length) ? lapArr[lapIndex + 2] : 0
+                    return ((lapArr[lapIndex] - prev) - (prev - prev2)) <= 0 ? "#AAEE44" : "#FF6644"
+                }
+            }
+
+            RowSeparator { pinToBottom: true }
+        }
+    }
+
+    // Fade mask — list scrolls under this, giving contrast to the delta label above
+    Rectangle {
+        anchors {
+            top: parent.top
+            left: parent.left
+            right: parent.right
+        }
+        height: Dims.h(40)
+        gradient: Gradient {
+            GradientStop { position: 0.0; color: "#FF000000" }
+            GradientStop { position: 1.0; color: "#00000000" }
+        }
+    }
+
+    // Current split or lap delta — tap to record a lap
+    Item {
+        anchors {
+            top: parent.top
+            left: parent.left
+            right: parent.right
+        }
+        height: Dims.h(40)
+
+        Label {
+            anchors.centerIn: parent
+            horizontalAlignment: Text.AlignHCenter
+            font.pixelSize: Dims.h(12)
+            text: {
+                var lapArr = lapPage.lapList
+                var cur = lapPage.elapsedMs < 0 ? 0 : lapPage.elapsedMs
+                if (!lapArr || lapArr.length === 0) {
+                    return toLapString(cur)
+                }
+                var curSplit = cur - lapArr[0]
+                if (lapArr.length < 2) {
+                    return toLapString(curSplit)
+                }
+                return toDeltaString(curSplit - (lapArr[0] - lapArr[1]))
+            }
+            color: {
+                var lapArr = lapPage.lapList
+                if (!lapArr || lapArr.length < 2) return "#CCCCF3"
+                var cur = lapPage.elapsedMs < 0 ? 0 : lapPage.elapsedMs
+                var curSplit = cur - lapArr[0]
+                var prev = lapArr[0] - lapArr[1]
+                return (curSplit - prev) <= 0 ? "#AAEE44" : "#FF6644"
+            }
+        }
+
+        MouseArea {
+            anchors.fill: parent
+            onClicked: lapPage.lapRecorded()
+        }
+    }
+}

--- a/src/StopwatchController.cpp
+++ b/src/StopwatchController.cpp
@@ -1,0 +1,130 @@
+/*
+ * Copyright (C) 2026 Timo Könnecke <github.com/moWerk>
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include "StopwatchController.h"
+#include <QSettings>
+#include <time.h>
+
+StopwatchController::StopwatchController(QObject *parent)
+    : QObject(parent)
+    , m_baseElapsed(-1)
+    , m_startBoottime(0)
+    , m_running(false)
+{
+    connect(&m_timer, &QTimer::timeout, this, &StopwatchController::elapsedChanged);
+    m_timer.setInterval(100);
+
+    QSettings s;
+    qint64 baseElapsed    = s.value(QStringLiteral("baseElapsed"), -1).toLongLong();
+    qint64 startBoottime  = s.value(QStringLiteral("startBoottime"), 0).toLongLong();
+    QStringList lapStrs   = s.value(QStringLiteral("laps")).toStringList();
+
+    for (const QString &str : lapStrs)
+        m_laps << QVariant::fromValue(str.toLongLong());
+
+    if (startBoottime > 0) {
+        // Was running when app last closed. Any reboot makes CLOCK_BOOTTIME
+        // less than the stored value so we cannot resume safely — invalidate.
+        if (boottimeMs() >= startBoottime) {
+            m_baseElapsed    = baseElapsed;
+            m_startBoottime  = startBoottime;
+            m_running        = true;
+            m_timer.start();
+        } else {
+            m_laps.clear();
+            save();
+        }
+    } else {
+        m_baseElapsed = baseElapsed;
+    }
+}
+
+QObject *StopwatchController::qmlInstance(QQmlEngine *engine, QJSEngine *scriptEngine)
+{
+    Q_UNUSED(engine)
+    Q_UNUSED(scriptEngine)
+    return new StopwatchController;
+}
+
+qint64 StopwatchController::boottimeMs() const
+{
+    struct timespec ts;
+    clock_gettime(CLOCK_BOOTTIME, &ts);
+    return (qint64)ts.tv_sec * 1000 + ts.tv_nsec / 1000000;
+}
+
+qint64 StopwatchController::elapsed() const
+{
+    if (m_baseElapsed < 0) return -1;
+    if (m_running) return m_baseElapsed + (boottimeMs() - m_startBoottime);
+    return m_baseElapsed;
+}
+
+void StopwatchController::save()
+{
+    QSettings s;
+    s.setValue(QStringLiteral("baseElapsed"), QVariant::fromValue(m_baseElapsed));
+    s.setValue(QStringLiteral("startBoottime"), QVariant::fromValue(m_startBoottime));
+    QStringList lapStrs;
+    for (const QVariant &v : m_laps)
+        lapStrs << QString::number(v.toLongLong());
+    s.setValue(QStringLiteral("laps"), lapStrs);
+}
+
+void StopwatchController::start()
+{
+    if (m_running) return;
+    if (m_baseElapsed < 0) m_baseElapsed = 0;
+    m_startBoottime = boottimeMs();
+    m_running = true;
+    m_timer.start();
+    emit runningChanged();
+    save();
+}
+
+void StopwatchController::stop()
+{
+    if (!m_running) return;
+    m_baseElapsed   = elapsed();
+    m_startBoottime = 0;
+    m_running       = false;
+    m_timer.stop();
+    emit runningChanged();
+    emit elapsedChanged();
+    save();
+}
+
+void StopwatchController::reset()
+{
+    m_timer.stop();
+    m_baseElapsed   = -1;
+    m_startBoottime = 0;
+    m_running       = false;
+    m_laps.clear();
+    emit runningChanged();
+    emit elapsedChanged();
+    emit lapsChanged();
+    save();
+}
+
+void StopwatchController::recordLap()
+{
+    if (!m_running) return;
+    m_laps.prepend(QVariant::fromValue(elapsed()));
+    emit lapsChanged();
+    save();
+}

--- a/src/StopwatchController.h
+++ b/src/StopwatchController.h
@@ -1,0 +1,68 @@
+/*
+ * Copyright (C) 2026 Timo Könnecke <github.com/moWerk>
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#ifndef STOPWATCHCONTROLLER_H
+#define STOPWATCHCONTROLLER_H
+
+#include <QObject>
+#include <QTimer>
+#include <QVariantList>
+#include <QQmlEngine>
+#include <QJSEngine>
+
+class StopwatchController : public QObject
+{
+    Q_OBJECT
+    Q_DISABLE_COPY(StopwatchController)
+
+    Q_PROPERTY(qint64 elapsed READ elapsed NOTIFY elapsedChanged)
+    Q_PROPERTY(bool running READ running NOTIFY runningChanged)
+    // Each entry is a qint64 elapsed timestamp in milliseconds at the moment
+    // the lap was recorded. Entries are prepended so index 0 is always the
+    // most recent lap.
+    Q_PROPERTY(QVariantList laps READ laps NOTIFY lapsChanged)
+
+public:
+    static QObject *qmlInstance(QQmlEngine *engine, QJSEngine *scriptEngine);
+
+    qint64 elapsed() const;
+    bool running() const { return m_running; }
+    QVariantList laps() const { return m_laps; }
+
+    Q_INVOKABLE void start();
+    Q_INVOKABLE void stop();
+    Q_INVOKABLE void reset();
+    Q_INVOKABLE void recordLap();
+
+signals:
+    void elapsedChanged();
+    void runningChanged();
+    void lapsChanged();
+
+private:
+    explicit StopwatchController(QObject *parent = nullptr);
+    qint64 boottimeMs() const;
+    void save();
+
+    QTimer m_timer;
+    qint64 m_baseElapsed;
+    qint64 m_startBoottime;
+    bool m_running;
+    QVariantList m_laps;
+};
+
+#endif // STOPWATCHCONTROLLER_H

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1,5 +1,6 @@
 /*
- * Copyright (C) 2017 - Florent Revest <revestflo@gmail.com>
+ * Copyright (C) 2026 Timo Könnecke <github.com/moWerk>
+ *               2017 Florent Revest <revestflo@gmail.com>
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -16,8 +17,12 @@
  */
 
 #include <asteroidapp.h>
+#include "StopwatchController.h"
 
 int main(int argc, char *argv[])
 {
+    qmlRegisterSingletonType<StopwatchController>(
+        "org.asteroid.stopwatch", 1, 0, "Stopwatch",
+        StopwatchController::qmlInstance);
     return AsteroidApp::main(argc, argv);
 }

--- a/src/main.qml
+++ b/src/main.qml
@@ -1,5 +1,6 @@
 /*
- * Copyright (C) 2016 Florent Revest <revestflo@gmail.com>
+ * Copyright (C) 2026 Timo Könnecke <github.com/moWerk>
+ *               2016 Florent Revest <revestflo@gmail.com>
  *               2015 Tim Süberkrüb <tim.sueberkrueb@web.de>
  * Part of this code is based on "Stopwatch" (https://github.com/baleboy/stopwatch)
  * Copyright (C) 2011 Francesco Balestrieri
@@ -111,16 +112,26 @@ Application {
                 }
         }
 
-        IconButton {
-            id: resetButton
-            iconName: "ios-refresh"
+        Item {
             visible: mainPage.state === "paused"
-            anchors { 
+            anchors {
+                top: elapsedLabel.bottom
                 bottom: parent.bottom
-                horizontalCenter: parent.horizontalCenter
-                bottomMargin: Dims.iconButtonMargin
+                left: parent.left
+                right: parent.right
             }
-            onClicked: elapsed.value = -1
+
+            Icon {
+                anchors.centerIn: parent
+                name: "ios-refresh"
+                width: Dims.l(24)
+                height: Dims.l(24)
+            }
+
+            MouseArea {
+                anchors.fill: parent
+                onClicked: elapsed.value = -1
+            }
         }
     }
 

--- a/src/main.qml
+++ b/src/main.qml
@@ -21,7 +21,7 @@
 
 import QtQuick 2.9
 import org.asteroid.controls 1.0
-import Nemo.Configuration 1.0
+import org.asteroid.stopwatch 1.0
 
 Application {
     id: app
@@ -29,21 +29,8 @@ Application {
     centerColor: "#9800A6"
     outerColor: "#0C0009"
 
-    ConfigurationValue {
-        id: previousTime
-        key: "/stopwatch/previousTime"
-        defaultValue: -1
-    }
-    ConfigurationValue {
-        id: elapsed
-        key: "/stopwatch/elapsed"
-        defaultValue: -1
-    }
-    ConfigurationValue {
-        id: running
-        key: "/stopwatch/running"
-        defaultValue: false
-    }
+    property string swState: Stopwatch.running ? "running"
+                           : Stopwatch.elapsed < 0 ? "zero" : "paused"
 
     function zeroPad(n) {
         return (n < 10 ? "0" : "") + n
@@ -70,24 +57,17 @@ Application {
         id: mainPage
         anchors.fill: parent
 
-        state: running.value ? "running" : elapsed.value == -1 ? "zero" : "paused"
-        states: [
-            State { name: "zero" },
-            State { name: "running" },
-            State { name: "paused" }
-        ]
-
         Label {
             id: elapsedLabel
             clip: false
             textFormat: Text.RichText
             anchors.centerIn: parent
-            text: toTimeString(elapsed.value)
+            text: toTimeString(Stopwatch.elapsed)
             font.pixelSize: Dims.h(25)
             horizontalAlignment: Text.AlignHCenter
 
             SequentialAnimation {
-                running: mainPage.state == "paused"
+                running: app.swState == "paused"
                 loops: Animation.Infinite
                 NumberAnimation { target: elapsedLabel; property: "opacity"; from: 1; to: 0; duration: 500 }
                 NumberAnimation { target: elapsedLabel; property: "opacity"; from: 0; to: 1; duration: 500 }
@@ -98,22 +78,20 @@ Application {
         MouseArea {
             anchors.fill: parent
                 onClicked: {
-                    switch(mainPage.state) {
+                    switch(app.swState) {
                         case "zero":
                         case "paused":
-                            var curTime = new Date
-                            previousTime.value = curTime.getTime()
-                            running.value = true
+                            Stopwatch.start()
                             break;
                         case "running":
-                            running.value = false
+                            Stopwatch.stop()
                             break;
                     }
                 }
         }
 
         Item {
-            visible: mainPage.state === "paused"
+            visible: app.swState === "paused"
             anchors {
                 top: elapsedLabel.bottom
                 bottom: parent.bottom
@@ -130,22 +108,8 @@ Application {
 
             MouseArea {
                 anchors.fill: parent
-                onClicked: elapsed.value = -1
+                onClicked: Stopwatch.reset()
             }
-        }
-    }
-
-    Timer {
-        interval: 100
-        repeat:  true
-        running: mainPage.state == "running"
-        triggeredOnStart: true
-
-        onTriggered: {
-            var currentTime = new Date
-            var delta = (currentTime.getTime() - previousTime.value)
-            previousTime.value = currentTime.getTime()
-            elapsed.value += delta
         }
     }
 }

--- a/src/main.qml
+++ b/src/main.qml
@@ -53,63 +53,106 @@ Application {
         }
     }
 
-    Item {
-        id: mainPage
+    function resetAll() {
+        Stopwatch.reset()
+        pageView.currentIndex = 0
+    }
+
+    ListView {
+        id: pageView
         anchors.fill: parent
+        orientation: ListView.Horizontal
+        snapMode: ListView.SnapOneItem
+        highlightRangeMode: ListView.StrictlyEnforceRange
+        flickDeceleration: 5000
+        flickableDirection: Flickable.HorizontalFlick
+        boundsBehavior: Flickable.StopAtBounds
+        model: 2
 
-        Label {
-            id: elapsedLabel
-            clip: false
-            textFormat: Text.RichText
-            anchors.centerIn: parent
-            text: toTimeString(Stopwatch.elapsed)
-            font.pixelSize: Dims.h(25)
-            horizontalAlignment: Text.AlignHCenter
+        delegate: Item {
+            width: pageView.width
+            height: pageView.height
 
-            SequentialAnimation {
-                running: app.swState == "paused"
-                loops: Animation.Infinite
-                NumberAnimation { target: elapsedLabel; property: "opacity"; from: 1; to: 0; duration: 500 }
-                NumberAnimation { target: elapsedLabel; property: "opacity"; from: 0; to: 1; duration: 500 }
-                onStopped: elapsedLabel.opacity = 1
-            }
-        }
+            Item {
+                anchors.fill: parent
+                visible: index === 0
 
-        MouseArea {
-            anchors.fill: parent
-                onClicked: {
-                    switch(app.swState) {
-                        case "zero":
-                        case "paused":
-                            Stopwatch.start()
-                            break;
-                        case "running":
-                            Stopwatch.stop()
-                            break;
+                Label {
+                    id: elapsedLabel
+                    clip: false
+                    textFormat: Text.RichText
+                    anchors.centerIn: parent
+                    text: toTimeString(Stopwatch.elapsed)
+                    font.pixelSize: Dims.h(25)
+                    horizontalAlignment: Text.AlignHCenter
+
+                    SequentialAnimation {
+                        running: app.swState == "paused"
+                        loops: Animation.Infinite
+                        NumberAnimation { target: elapsedLabel; property: "opacity"; from: 1; to: 0; duration: 500 }
+                        NumberAnimation { target: elapsedLabel; property: "opacity"; from: 0; to: 1; duration: 500 }
+                        onStopped: elapsedLabel.opacity = 1
                     }
                 }
-        }
 
-        Item {
-            visible: app.swState === "paused"
-            anchors {
-                top: elapsedLabel.bottom
-                bottom: parent.bottom
-                left: parent.left
-                right: parent.right
+                MouseArea {
+                    anchors.fill: parent
+                        onClicked: {
+                            switch(app.swState) {
+                                case "zero":
+                                case "paused":
+                                    Stopwatch.start()
+                                    break;
+                                case "running":
+                                    Stopwatch.stop()
+                                    break;
+                            }
+                        }
+                }
+
+                Item {
+                    visible: app.swState === "paused"
+                    anchors {
+                        top: elapsedLabel.bottom
+                        bottom: parent.bottom
+                        left: parent.left
+                        right: parent.right
+                    }
+
+                    Icon {
+                        anchors.centerIn: parent
+                        name: "ios-refresh"
+                        width: Dims.l(24)
+                        height: Dims.l(24)
+                    }
+
+                    MouseArea {
+                        anchors.fill: parent
+                        onClicked: Stopwatch.reset()
+                    }
+                }
             }
 
-            Icon {
-                anchors.centerIn: parent
-                name: "ios-refresh"
-                width: Dims.l(24)
-                height: Dims.l(24)
-            }
-
-            MouseArea {
+            LapPage {
                 anchors.fill: parent
-                onClicked: Stopwatch.reset()
+                visible: index === 1
+                elapsedMs: Stopwatch.elapsed
+                swState: app.swState
+                lapList: Stopwatch.laps
+                onLapRecorded: Stopwatch.recordLap()
             }
         }
+    }
+
+    PageDot {
+        anchors {
+            horizontalCenter: parent.horizontalCenter
+            bottom: parent.bottom
+            bottomMargin: Dims.h(2)
+        }
+        height: Dims.h(2)
+        dotNumber: 2
+        currentIndex: pageView.currentIndex
+        visible: !(app.swState === "paused" && pageView.currentIndex === 0)
     }
 }

--- a/src/resources.qrc
+++ b/src/resources.qrc
@@ -1,5 +1,6 @@
 <RCC>
     <qresource prefix="/">
         <file>main.qml</file>
+        <file>LapPage.qml</file>
     </qresource>
 </RCC>


### PR DESCRIPTION

This PR addresses two long-standing bug reports and implements the most requested missing feature of asteroid-stopwatch.

## Bug fixes:

**The reset button** was represented by an IconButton whose tappable area was limited to the icon bounding box, making it easy to miss on a small watch screen. The button zone now covers the full lower third of the screen from the elapsed label to the screen bottom, with the icon centered visually within it. The zone is structured to split horizontally if a second button is added in the future.

**Time change fix:** Updated behavior after reviews:
On app restart after the watch clock was changed by NTP, DST transition or manual adjustment, the catch-up delta applied to elapsed was calculated from wall clock time, causing the displayed time to jump by the amount the clock had shifted.

Following review feedback this was reworked into a proper C++ singleton `StopwatchController` that owns all timing logic. Elapsed is computed live from `CLOCK_BOOTTIME`, a monotonic kernel clock that ticks through suspend and is completely immune to wall clock changes. QML retains ownership of all dconf persistence and calls `restore()` on startup,
passing in the persisted values. The controller compares the saved `startBoottime` against the current `CLOCK_BOOTTIME` to detect reboots. If the current value is less than the stored one, the session is invalidated cleanly. Paused sessions are always restored as-is since they carry no timing dependency. State is written to dconf only on actual state transitions, not on the 100ms display tick.

## New feature:

A dedicated lap page is added as LapPage.qml with a primitives-only interface. Both pages are always present and indicated by a PageDot. The PageDot is hidden when paused on page 0 to avoid collision with the reset icon. Page 0 is visually unchanged.

![shot-stop1](https://github.com/user-attachments/assets/26642e16-7442-4bd9-9bac-65a4af6588f7)
First page unchanged layout with page dots added.

The lap page shows a live delta header at the top that transitions from total elapsed with no laps, to current split duration after the first lap, to a colored faster/slower delta from the second lap onward. Tapping the header records a lap. Below it a full-page scrollable ListView shows a live current row at the top and all historical rows below it, newest first, each showing lap number, split time and colored split delta. A gradient fade gives the header contrast as the list scrolls beneath it. Round screen devices get an extended footer to prevent the last row from being clipped. Lap data persists across restarts via ConfigurationValue.

Behaviour after implementing the review comments:
https://github.com/user-attachments/assets/74fc2738-6238-4f80-abd8-a77516bd8fe7



![shot-stop3](https://github.com/user-attachments/assets/2217b566-3755-408d-b075-fe334fc27251)
Positive delta

![shot-stop2](https://github.com/user-attachments/assets/6e58a4e7-df36-4fae-9603-3f52074ac1e7)
Negative delta

![shot-stop4](https://github.com/user-attachments/assets/a82cc5ee-84a1-4964-bfc7-cbcd1c7d664d)
Scrolled down

Fixes: https://github.com/AsteroidOS/asteroid-stopwatch/issues/12
Fixes: https://github.com/AsteroidOS/asteroid-stopwatch/issues/13
Fixes: https://github.com/AsteroidOS/asteroid-stopwatch/issues/6